### PR TITLE
Changed submodule path with minor fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "startbootstrap-clean-blog"]
 	path = startbootstrap-clean-blog
-	url = git@github.com:BlackrockDigital/startbootstrap-clean-blog.git
+	url = https://github.com/StartBootstrap/startbootstrap-clean-blog

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ track-version:
 
 .PHONY: cp-all
 cp-all:
-	cp startbootstrap-clean-blog/dist/css/* static/css/; \
-	cp startbootstrap-clean-blog/dist/js/* static/js/; \
-	cp startbootstrap-clean-blog/assets/img/* static/img/; \
-	cp startbootstrap-clean-blog/assets/favicon.ico static/
+	cp ./startbootstrap-clean-blog/dist/css/* static/css/; \
+	cp ./startbootstrap-clean-blog/dist/js/* static/js/; \
+	cp ./startbootstrap-clean-blog/dist/assets/img/* static/img/; \
+	cp ./startbootstrap-clean-blog/dist/assets/favicon.ico static/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 ![Sample Page](./docs/hugo-clean-blog-sample.png)
 
-Hugo theme based on [Start Bootstrap Clean Blog](http://startbootstrap.com/template-overviews/clean-blog/). Please also see [Start Bootstrap - Clean Blog](https://github.com/startbootstrap/startbootstrap-clean-blog).
+Hugo theme based on [Start Bootstrap Clean Blog](http://startbootstrap.com/template-overviews/clean-blog/).
+Please also see orignal theme → [Start Bootstrap - Clean Blog](https://github.com/startbootstrap/startbootstrap-clean-blog).
 
 ## Goal of this theme
 
@@ -19,7 +20,7 @@ Hugo theme based on [Start Bootstrap Clean Blog](http://startbootstrap.com/templ
 In your Hugo project, type following.
 
 ```bash
-git submodule add https://github.com/Go-zen-chu/hugo-clean-blog-theme.git themes/clean-blog
+git submodule add https://github.com/go-zen-chu/hugo-clean-blog-theme.git themes/clean-blog
 ```
 
 From config.toml of your site, specify
@@ -30,18 +31,32 @@ theme = "clean-blog"
 
 ## How to develop this theme
 
-### Update to latest clean-blog style
+### Check how theme works with sample project
 
 ```bash
-vim Makefile
+git clone https://github.com/go-zen-chu/hugo-clean-blog-theme-sample
+# if you clone repo above you also get stable version theme via submodule
+pushd themes/clean-blog
+git checkout -b <any-branch-for-development>
+# develop your theme
+popd
+# check updated theme works
+hugo serve -D
+```
+
+#### Update to latest clean-blog style
+
+```bash
+pushd themes/clean-blog
 # update to latest tag
 make track-version
 ```
 
-### Copy css, js and other assets from original theme
+#### Copy css, js and other assets from original bootstrap theme
 
-This theme uses [Start Bootstrap Clean Blog](https://github.com/startbootstrap/startbootstrap-clean-blog), so we need to bring all static things to this theme.
+This theme uses [Start Bootstrap Clean Blog](https://github.com/startbootstrap/startbootstrap-clean-blog), so we bring all static files to this hugo theme.
 
 ```bash
+pushd themes/clean-blog
 make cp-all
 ```

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,14 +3,12 @@
 
 <head>
     <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <meta name="description" content="{{ if .Description }}{{ .Description }}{{ end }}">
+    <meta name="description" content="{{ if .Description }}{{ .Description }}{{ end }}" />
     <meta name="author"
-        content="{{ if .Params.author }}{{ .Params.author }}{{ else if .Site.Params.Author }}{{ .Site.Params.Author }}{{ end }}">
+        content="{{ if .Params.author }}{{ .Params.author }}{{ else if .Site.Params.Author }}{{ .Site.Params.Author }}{{ end }}" />
     <meta name="keywords" content="{{ if .Keywords }}{{ delimit .Keywords " , " }}{{ end }}">
-
-    <title>{{ .Title }} -- {{ .Site.Title }}</title>
+    <title>{{ .Title }} - {{ .Site.Title }}</title>
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <!-- Font Awesome icons (free version)-->
     <script src="https://use.fontawesome.com/releases/v6.1.0/js/all.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- submodule path `git@github.com:BlackrockDigital/startbootstrap-clean-blog.git` is old and it's moved to github.com/StartBootstrap/startbootstrap-clean-blog

## What
<!-- What features are added in this PR -->
- changed submodules path
- update readme for better clarification
- fix makefile cp-all

## QA, Evidence
<!-- Things that support this PR is correct -->
- [checked with sample repo](https://github.com/go-zen-chu/hugo-clean-blog-theme-sample/pull/1)
- https://dreamy-hoover-3f3499.netlify.app/